### PR TITLE
Add project-level Claude Code permission allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(uv run ruff check *)",
+      "Bash(set -a && source .env && set +a && uv run ruff check *)",
+      "Bash(set -a && source .env && set +a && uv run pytest *)",
+      "mcp__github__get_file_contents"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,8 @@
 {
   "permissions": {
     "allow": [
-      "Bash(uv run ruff check *)",
-      "Bash(set -a && source .env && set +a && uv run ruff check *)",
+      "Bash(uv run ruff check .)",
+      "Bash(set -a && source .env && set +a && uv run ruff check .)",
       "Bash(set -a && source .env && set +a && uv run pytest *)",
       "mcp__github__get_file_contents"
     ]


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` at the repo root with a `permissions.allow` list so Claude Code's Auto Mode doesn't drop to Accept Edits mode
- Pre-approves four read-only/common command patterns identified from session transcripts

## What changed

New file: `.claude/settings.json`

| Pattern | Why |
|---------|-----|
| `Bash(uv run ruff check *)` | Linting — read-only, safe to auto-approve |
| `Bash(set -a && source .env && set +a && uv run ruff check *)` | Same lint check but with env sourcing prefix (common invocation pattern) |
| `Bash(set -a && source .env && set +a && uv run pytest *)` | Test runner with env sourcing — needed for Auto Mode to run tests unattended |
| `mcp__github__get_file_contents` | Read-only GitHub MCP file fetches |

## Notes for reviewer

- `uv run pytest` was already in the global `~/.claude/settings.json` allowlist, but the compound `set -a && source .env && set +a && uv run pytest ...` form (which is how tests are actually invoked in this repo) wasn't matched by that rule — hence the new entry
- No mutation commands are allowlisted; `Edit`/`Write` tool calls still require per-session approval
- `settings.local.json` (gitignored, per-user) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)