### PR TITLE
Fix Claude workflows missing write permissions for PR comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,8 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary

- `pull-requests` and `issues` permissions were set to `read` in both Claude workflows
- The GitHub API rejects comment writes without `write` permission, so Claude could run but never post its output
- Updated both `claude-code-review.yml` and `claude.yml` to use `write` for these permissions

## Test plan

- [ ] Open a new PR and confirm Claude Code Review posts inline comments
- [ ] Tag `@claude` in an issue/PR comment and confirm it replies

🤖 Generated with [Claude Code](https://claude.com/claude-code)