### PR TITLE
Allow hyphens in school name validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -693,7 +693,8 @@ def autofill():
 def api_validate_name(form_item_name):
     form_item = request.form.get(form_item_name)
     form_item_id = request.args.get("id", form_item_name)
-    form_item_valid = bool(form_item) and form_item.replace(" ", "").isalpha()
+    stripped = form_item.replace(" ", "").replace("-", "") if form_item else ""
+    form_item_valid = bool(form_item) and bool(stripped) and stripped.isalpha()
     return render_template(
         "validation/name.html",
         form_item=form_item,

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -1104,6 +1104,19 @@ class TestNameValidation:
         assert response.status_code == 200
         assert b"is-valid" in response.data
 
+    def test_valid_name_with_hyphen(self):
+        response = self.client.post(
+            "/api/validate/name/unlistedSchool",
+            data={"unlistedSchool": "Golden Dragon TKD - South Tulsa"},
+        )
+        assert response.status_code == 200
+        assert b"is-valid" in response.data
+
+    def test_invalid_name_only_hyphens(self):
+        response = self.client.post("/api/validate/name/fname", data={"fname": "---"})
+        assert response.status_code == 200
+        assert b"is-invalid" in response.data
+
 
 class TestNumberValidation:
     client = app.test_client()

--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -1117,6 +1117,11 @@ class TestNameValidation:
         assert response.status_code == 200
         assert b"is-invalid" in response.data
 
+    def test_invalid_name_spaces_and_hyphens_only(self):
+        response = self.client.post("/api/validate/name/fname", data={"fname": "- -"})
+        assert response.status_code == 200
+        assert b"is-invalid" in response.data
+
 
 class TestNumberValidation:
     client = app.test_client()


### PR DESCRIPTION
## Summary

- Fixes the name validator rejecting school names that contain a `-` character (e.g. `Golden Dragon TKD - South Tulsa`)
- Strips hyphens (in addition to spaces) before the `isalpha()` check, while still requiring at least one alphabetic character so strings like `---` remain invalid
- Adds two new tests: one confirming hyphenated school names pass, one confirming hyphen-only strings still fail

Closes #67

---
_Generated by [Claude Code](https://claude.ai/code/session_016fZ2aUK2Ef5ZonEJQVNmog)_