### PR TITLE
Optimize age_group_for(): module-level flat lookup map

### DIFF
--- a/models.py
+++ b/models.py
@@ -242,7 +242,7 @@ _AGE_GROUP_MAP: dict[int, str] = {
 }
 
 
-def age_group_for(age) -> str:
+def age_group_for(age: int | str) -> str:
     """Map an integer age to its competition age-group name."""
     return _AGE_GROUP_MAP.get(int(age), "too_old")
 

--- a/models.py
+++ b/models.py
@@ -230,19 +230,21 @@ class Competitor(db.Model):
 # ---------------------------------------------------------------------------
 
 
+_AGE_GROUP_MAP: dict[int, str] = {
+    **{a: "too_young" for a in range(0, 4)},
+    **{a: "dragon"    for a in [4, 5, 6, 7]},
+    **{a: "tiger"     for a in [8, 9]},
+    **{a: "youth"     for a in [10, 11]},
+    **{a: "cadet"     for a in [12, 13, 14]},
+    **{a: "junior"    for a in [15, 16]},
+    **{a: "senior"    for a in range(17, 33)},
+    **{a: "ultra"     for a in range(33, 100)},
+}
+
+
 def age_group_for(age) -> str:
     """Map an integer age to its competition age-group name."""
-    age_groups = {
-        "too_young": list(range(0, 4)),
-        "dragon": [4, 5, 6, 7],
-        "tiger": [8, 9],
-        "youth": [10, 11],
-        "cadet": [12, 13, 14],
-        "junior": [15, 16],
-        "senior": list(range(17, 33)),
-        "ultra": list(range(33, 100)),
-    }
-    return next((group for group, ages in age_groups.items() if int(age) in ages), "too_old")
+    return _AGE_GROUP_MAP.get(int(age), "too_old")
 
 
 def entry_exists(full_name: str, school_id: int, reg_type: str) -> bool:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,49 @@
+"""Unit tests for pure helper functions in models.py."""
+
+import os
+import sys
+
+import pytest
+
+base_path = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, os.path.dirname(base_path))
+
+from models import age_group_for  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "age, expected",
+    [
+        # too_young boundary
+        (0,   "too_young"),
+        (3,   "too_young"),
+        # dragon
+        (4,   "dragon"),
+        (7,   "dragon"),
+        # tiger
+        (8,   "tiger"),
+        (9,   "tiger"),
+        # youth
+        (10,  "youth"),
+        (11,  "youth"),
+        # cadet
+        (12,  "cadet"),
+        (14,  "cadet"),
+        # junior
+        (15,  "junior"),
+        (16,  "junior"),
+        # senior boundaries
+        (17,  "senior"),
+        (32,  "senior"),
+        # ultra boundaries
+        (33,  "ultra"),
+        (99,  "ultra"),
+        # too_old (outside map)
+        (100, "too_old"),
+        (-1,  "too_old"),
+        # string input coercion
+        ("17", "senior"),
+    ],
+)
+def test_age_group_for(age, expected):
+    assert age_group_for(age) == expected


### PR DESCRIPTION
## Summary

- Moves the age-group dict out of `age_group_for()` into a module-level constant `_AGE_GROUP_MAP` (flattened to a direct `age → group` mapping)
- Replaces the O(n) `next(...)` linear scan with a single O(1) `dict.get()` call
- Dict is now built once at import time instead of on every call (birthdate validation, autofill requests, weight-class annotation passes)

Closes #68

## Test plan

- [ ] `uv run ruff check models.py` — passes (verified locally)
- [ ] Manually confirm `age_group_for()` still returns correct groups for boundary ages (e.g. 3→`too_young`, 4→`dragon`, 16→`junior`, 17→`senior`, 32→`senior`, 33→`ultra`, 99→`ultra`, 100→`too_old`)

https://claude.ai/code/session_01KfPAahBYtStzC2ihS7x5x9

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfPAahBYtStzC2ihS7x5x9)_