### PR TITLE
Enable inline PR comments and scope allowed tools in code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,7 +38,14 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # --comment is required for the plugin to post review comments;
+          # without it the plugin only prints a summary to the CI log and posts nothing.
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          # Scoped to exactly what the code-review plugin declares it needs.
+          # Read/Grep/Glob + Task: review subagents read code and fan out.
+          # Bash(gh ...): fetch PR data. mcp__github_inline_comment: post inline comments.
+          # No Write/Edit/WebFetch — review never mutates the repo or browses the web.
+          allowed_tools: 'Read,Grep,Glob,Task,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),mcp__github_inline_comment__create_inline_comment'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary

- Adds `--comment` flag to the code-review prompt so the plugin posts inline review comments on the PR instead of just printing a summary to CI logs
- Scopes `allowed_tools` to exactly what the plugin needs: read-only tools (`Read`, `Grep`, `Glob`, `Task`), targeted `gh` CLI commands for fetching PR data, and `mcp__github_inline_comment__create_inline_comment` for posting comments
- No `Write`, `Edit`, or `WebFetch` — the review workflow never mutates the repo or browses the web

## Test plan

- [ ] Open a new PR and confirm the code-review job runs and posts inline comments
- [ ] Verify the job completes without permission errors given the scoped `allowed_tools`

🤖 Generated with [Claude Code](https://claude.com/claude-code)