### PR TITLE
Remove dead JWT auth scaffolding from TestEntriesAPI tests

### DIFF
--- a/tests/test_website.py
+++ b/tests/test_website.py
@@ -301,25 +301,6 @@ class TestEntriesAPI:
         for field in ("email", "phone", "status", "checkout_session_id", "payment_intent"):
             assert field not in entry, f"Private field '{field}' should not be in public response"
 
-    def test_response_code(self):
-        with (
-            patch.dict(os.environ, {"SUPABASE_JWT_SECRET": "test_secret"}),
-            api_mock_jwt(),
-            patch("api.set_weight_class", return_value=[]),
-        ):
-            response = self.client.get("/api/v1/entries", headers=api_auth_headers())
-        assert response.status_code == 200
-
-    def test_returns_json(self):
-        with (
-            patch.dict(os.environ, {"SUPABASE_JWT_SECRET": "test_secret"}),
-            api_mock_jwt(),
-            patch("api.set_weight_class", return_value=[]),
-        ):
-            response = self.client.get("/api/v1/entries", headers=api_auth_headers())
-        data = json.loads(response.data)
-        assert "data" in data
-
     def test_returns_competitor_and_coach_entries(self):
         from models import Coach, Competitor
         from models import db as _db
@@ -345,12 +326,8 @@ class TestEntriesAPI:
             c_id = competitor.id
             co_id = coach.id
 
-        with (
-            patch.dict(os.environ, {"SUPABASE_JWT_SECRET": "test_secret"}),
-            api_mock_jwt(),
-            patch("api.set_weight_class", return_value=[{"id": c_id, "full_name": "Jane Doe", "reg_type": "competitor"}]),
-        ):
-            response = self.client.get("/api/v1/entries", headers=api_auth_headers())
+        with patch("api.set_weight_class", return_value=[{"id": c_id, "full_name": "Jane Doe", "reg_type": "competitor"}]):
+            response = self.client.get("/api/v1/entries")
         data = json.loads(response.data)
         entries = data["data"]
         assert any(entry.get("id") == c_id and entry.get("reg_type") == "competitor" for entry in entries)
@@ -446,12 +423,8 @@ class TestEntriesAPI:
             complete_id = complete.id
             pending_id = pending.id
 
-        with (
-            patch.dict(os.environ, {"SUPABASE_JWT_SECRET": "test_secret"}),
-            api_mock_jwt(),
-            patch("api.set_weight_class", side_effect=lambda entries, _: entries),
-        ):
-            response = self.client.get("/api/v1/entries?status=complete", headers=api_auth_headers())
+        with patch("api.set_weight_class", side_effect=lambda entries, _: entries):
+            response = self.client.get("/api/v1/entries?status=complete")
         data = json.loads(response.data)
         entries = data["data"]
         result_ids = [e.get("id") for e in entries if e.get("reg_type") == "competitor"]


### PR DESCRIPTION
## Summary

- `GET /api/v1/entries` is a public endpoint (no `@api_auth_required` decorator); the JWT env patches, `api_mock_jwt()` calls, and auth headers in its tests were dead weight that falsely implied auth is required
- Delete `test_response_code`: exact semantic duplicate of the already-existing `test_entries_api_is_public`
- Delete `test_returns_json`: its `"data" in data` assertion is fully subsumed by `test_entries_api_strips_private_fields` and `test_returns_competitor_and_coach_entries`
- Simplify `test_returns_competitor_and_coach_entries` and `test_entries_endpoint_status_query_param`: replace 3-context-manager `with` blocks with a single `patch("api.set_weight_class", ...)`, consistent with the rest of the class

Closes #71

## Test plan

- [x] `uv run pytest tests/test_website.py::TestEntriesAPI` — 6 tests pass
- [x] Full test suite — 233 tests pass
- [x] `uv run ruff check .` — all checks passed
- [x] Manual cURL against local server: `GET /api/v1/entries` returns 200 with no auth headers; `?status=complete` filter works; no private fields in response
- [x] Code reviewer (whole-changeset review): 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)