### PR TITLE
Document is_new=False behavior in School.get_or_create() race-condition path

### DIFF
--- a/models.py
+++ b/models.py
@@ -48,6 +48,8 @@ class School(db.Model):
                 db.session.flush([school])  # scope flush to school so savepoint rollback can't undo other pending objects
             return school, True
         except IntegrityError:
+            # Another request created the school concurrently; treat as pre-existing so the
+            # first caller's new-school alert is not duplicated.
             return cls.query.filter_by(name=name).first(), False
 
     @classmethod
@@ -338,6 +340,8 @@ def create_entry(body: dict) -> tuple:
 
     db.session.add(reg)
     db.session.flush()
+    # is_new is False both for pre-existing schools and for the losing side of a concurrent
+    # insert (IntegrityError path in get_or_create); in either case, skip the alert.
     return reg, None, None, school.name if is_new else None
 
 


### PR DESCRIPTION
## Summary

- Adds a comment in `School.get_or_create()` explaining that the `IntegrityError` path returns `is_new=False` because the school was just created by a concurrent request, not because it was pre-existing
- Adds a comment in `create_entry()` clarifying that skipping the new-school alert when `is_new=False` is intentional — the winning concurrent caller already sent it

Closes #72

## Test plan

- [ ] All 233 existing tests pass (`uv run pytest`)
- [ ] No behavior changes — comments only

🤖 Generated with [Claude Code](https://claude.com/claude-code)